### PR TITLE
Add code of conduct

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -28,6 +28,9 @@ Confirm the following by editing each check box to '[x]'
   of developments in the _Bioconductor_ community, responding promptly
   to requests for updates from the Core team in response to changes in
   _R_ or underlying software.
+  
+- [ ] I am familiar with the [Bioconductor code of conduct][7] and 
+  agree to abide by it.
 
 I am familiar with the essential aspects of _Bioconductor_ software
 management, including:
@@ -47,3 +50,4 @@ to the [bioc-devel][4] mailing list.
 [4]: https://stat.ethz.ch/mailman/listinfo/bioc-devel
 [5]: http://bioconductor.org/developers/how-to/git/
 [6]: http://bioconductor.org/developers/how-to/git/sync-existing-repositories/
+[7]: https://bioconductor.org/about/code-of-conduct/


### PR DESCRIPTION
Hi,

This PR is part of the Code of Conduct dissemination activities. The BioC Code of Conduct committee thinks that it would be useful to have new contributors verify that they are aware of the code of conduct and that they will abide by it.

If you think that the wording needs to change, please feel free to edit the PR. I took the "abide by it" part from the code of conduct itself.

Best,
Leo